### PR TITLE
--show-disabled should only show disabled programs

### DIFF
--- a/src/bbrf_api.py
+++ b/src/bbrf_api.py
@@ -189,7 +189,7 @@ class BBRFApi:
     '''
     def get_programs(self, show_disabled=False, show_empty_scope=False):
         if show_disabled:
-            r = self.requests_session.get(self.BBRF_API+'/_design/bbrf/_view/programs?reduce=false', headers={"Authorization": self.auth})
+            r = self.requests_session.get(self.BBRF_API+'/_design/bbrf/_view/programs?reduce=false&key=true', headers={"Authorization": self.auth})
         else:
             r = self.requests_session.get(self.BBRF_API+'/_design/bbrf/_view/programs?reduce=false&key=false', headers={"Authorization": self.auth})
         if 'error' in r.json():


### PR DESCRIPTION
This PR makes it easier to just see the programs you have disabled because right now it's not easy to figure out that.

Current output of `bbrf programs`:
```
$ bbrf programs
enabled_1
enabled_2

$ bbrf programs --show-disabled
enabled_program_1
enabled_program_2
disabled_program
```

Output after this PR:
```
$ bbrf programs
enabled_program_1
enabled_program_2

$ bbrf programs --show-disabled
disabled_program
```