### PR TITLE
Fix domain update with ipv6

### DIFF
--- a/src/bbrf.py
+++ b/src/bbrf.py
@@ -378,7 +378,7 @@ class BBRFClient:
             
             # split ips if provided
             if ':' in domain:
-                domain, ips = domain.split(':')
+                domain, ips = domain.split(':',1)
                 ips = ips.split(',')
                 
                 for ip in ips:


### PR DESCRIPTION
domains such as following are parsed correctly when added, but incorrect when updated:

```sh
bbrf domain update test.com:1:2:3:4:5
```